### PR TITLE
Added :when => Proc { |feature_name| ... } to states declaration

### DIFF
--- a/lib/feature_flipper/config.rb
+++ b/lib/feature_flipper/config.rb
@@ -43,15 +43,18 @@ module FeatureFlipper
       feature ? feature[:state] : nil
     end
 
-    def self.active_state?(state)
+    def self.active_state?(state, feature_name)
       active = states[state]
-      if active.is_a?(Hash)
+      case
+      when active.is_a?(Hash)
         if active.has_key?(:feature_group)
           group, required_state = active[:feature_group], active[:required_state]
         else
           group, required_state = active.to_a.flatten
         end
         (FeatureFlipper.active_feature_groups.include?(group)) || (states[required_state] == true)
+      when active.is_a?(Proc)
+        active.call(feature_name) == true
       else
         active == true
       end
@@ -62,14 +65,14 @@ module FeatureFlipper
 
       state = get_state(feature_name)
       if state.is_a?(Symbol)
-        active_state?(state)
+        active_state?(state, feature_name)
       elsif state.is_a?(Proc)
         state.call == true
       else
         state == true
       end
     end
-    
+
     def self.active_features
       self.features.collect { |key, value| self.is_active?(key) ? key : nil }.compact
     end

--- a/lib/feature_flipper/config.rb
+++ b/lib/feature_flipper/config.rb
@@ -69,6 +69,10 @@ module FeatureFlipper
         state == true
       end
     end
+    
+    def self.active_features
+      self.features.collect { |key, value| self.is_active?(key) ? key : nil }.compact
+    end
   end
 
   class Mapper

--- a/lib/feature_flipper/show.rb
+++ b/lib/feature_flipper/show.rb
@@ -7,11 +7,11 @@ module FeatureFlipper
     end
 
     def show_feature?(feature_name)
-      FeatureFlipper::Config.is_active?(feature_name)
+      FeatureFlipper::Config.is_active?(feature_name, self)
     end
-    
+
     def active_features
-      FeatureFlipper::Config.active_features
+      FeatureFlipper::Config.active_features(self)
     end
   end
 end

--- a/lib/feature_flipper/show.rb
+++ b/lib/feature_flipper/show.rb
@@ -9,5 +9,9 @@ module FeatureFlipper
     def show_feature?(feature_name)
       FeatureFlipper::Config.is_active?(feature_name)
     end
+    
+    def active_features
+      FeatureFlipper::Config.active_features
+    end
   end
 end

--- a/test/context.rb
+++ b/test/context.rb
@@ -1,0 +1,7 @@
+class Context
+  attr_reader :current_user_betas
+
+  def initialize(*betas)
+    @current_user_betas = betas
+  end
+end

--- a/test/feature_flipper_test.rb
+++ b/test/feature_flipper_test.rb
@@ -72,8 +72,13 @@ context 'DSL based FeatureFlipper' do
   end
 
   test 'show feature should work with state procs' do
+    Rails.stubs(:env).returns('production')
     assert show_feature?(:enabled_beta_feature)
     assert !show_feature?(:disabled_beta_feature)
+  end
+
+  test 'show feature should with state procs should still respect environment' do
+    assert show_feature?(:disabled_beta_feature)
   end
 
 end

--- a/test/feature_flipper_test.rb
+++ b/test/feature_flipper_test.rb
@@ -123,3 +123,19 @@ context 'dynamic feature groups' do
     assert show_feature?(:employee_feature)
   end
 end
+
+context 'context binding' do
+  setup { @context = Context.new(:feature1, :feature3) }
+
+  test 'should have feature 1' do
+    assert @context.show_feature?(:feature1)
+  end
+
+  test 'should not have feature 2' do
+    assert !@context.show_feature?(:feature2)
+  end
+
+  test 'should return active features' do
+
+  end
+end

--- a/test/feature_flipper_test.rb
+++ b/test/feature_flipper_test.rb
@@ -57,7 +57,7 @@ context 'DSL based FeatureFlipper' do
     assert show_feature?(:boolean_feature)
   end
 
-  test 'show feature should work with procs' do
+  test 'show feature should work with feature procs' do
     assert show_feature?(:proc_feature)
   end
 
@@ -70,6 +70,12 @@ context 'DSL based FeatureFlipper' do
     assert_equal :dev, all_features[:dev_feature][:state]
     assert_equal 'dev feature', all_features[:dev_feature][:description]
   end
+
+  test 'show feature should work with state procs' do
+    assert show_feature?(:enabled_beta_feature)
+    assert !show_feature?(:disabled_beta_feature)
+  end
+
 end
 
 context 'dynamic feature groups' do

--- a/test/features_dsl.rb
+++ b/test/features_dsl.rb
@@ -14,10 +14,16 @@ FeatureFlipper.features do
   in_state Proc.new { Date.today > Date.today - 84000 } do
     feature :proc_feature
   end
+
+  in_state :beta do
+    feature :enabled_beta_feature
+    feature :disabled_beta_feature
+  end
 end
 
 
 FeatureFlipper::Config.states = {
   :dev      => ['development', 'test'].include?(Rails.env),
-  :live     => true
+  :live     => true,
+  :beta     => Proc.new { |feature| %{ enabled_beta_feature }.include?(feature.to_s) }
 }

--- a/test/features_dsl.rb
+++ b/test/features_dsl.rb
@@ -19,11 +19,18 @@ FeatureFlipper.features do
     feature :enabled_beta_feature
     feature :disabled_beta_feature
   end
+
+  in_state :context do
+    feature :feature1
+    feature :feature2
+    feature :feature3
+  end
 end
 
 
 FeatureFlipper::Config.states = {
   :dev      => ['development', 'test'].include?(Rails.env),
   :live     => true,
-  :beta     => { :required_state => :dev, :when => Proc.new { |feature| %{ enabled_beta_feature }.include?(feature.to_s) } }
+  :beta     => { :required_state => :dev, :when => Proc.new { |feature| %{ enabled_beta_feature }.include?(feature.to_s) } },
+  :context  => { :when => Proc.new { |feature| current_user_betas.include?(feature) } }
 }

--- a/test/features_dsl.rb
+++ b/test/features_dsl.rb
@@ -25,5 +25,5 @@ end
 FeatureFlipper::Config.states = {
   :dev      => ['development', 'test'].include?(Rails.env),
   :live     => true,
-  :beta     => Proc.new { |feature| %{ enabled_beta_feature }.include?(feature.to_s) }
+  :beta     => { :required_state => :dev, :when => Proc.new { |feature| %{ enabled_beta_feature }.include?(feature.to_s) } }
 }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,3 +36,4 @@ module Rails
 end
 
 require 'feature_flipper'
+require 'context'


### PR DESCRIPTION
This is needed for more detailed decision-making of whether a certain user has access to a certain feature. We use this for allowing certain users to be in a beta group with access to one or more unreleased features.

I've refactored the active_state? method in config.rb quite a lot to make it more readable and support providing a Proc with the :when key in the state hash. I've also changed show.rb to provide self as the context when making calls to is_active? and active_features. If the context is available, the :when Proc will be called bound to this context, allowing the Proc to access methods that is unavailable in the context it was originally declared.

Example:

FeatureFlipper::Config.states = {
  :beta         => {:required_state => :staff, :when => Proc.new { |feature_name| current_user.present? && current_user.betas.include?(feature_name.to_s) } }
}

While these changes should be backwards compatiable (I haven't changed any of the existing tests, and they all still pass), I suggest we bump the version of the gem after pulling in this request.
