### PR TITLE
Fix a typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ A state is just a name and a boolean check. The check needs to evaluate to
 ```ruby
 FeatureFlipper.states do
   state :development, ['development', 'test'].include?(Rails.env)
-  state :staging, ['staging', development', 'test'].include?(Rails.env)
+  state :staging, ['staging', 'development', 'test'].include?(Rails.env)
 end
 ```
 


### PR DESCRIPTION
Saw a small typo in the example code - a missing bracket.